### PR TITLE
Force upgrade to 1.3.5, close digitevent/orchestration#583

### DIFF
--- a/upgrades.json
+++ b/upgrades.json
@@ -1,22 +1,22 @@
 {
     "platforms": {
         "android": {
-            "minAppVersion": "1.2.15",
+            "minAppVersion": "1.3.5",
             "releaseNotes": {
-                "en": "- improve stability & minor fixes",
-                "fr": "- amélioration de la stabilité et corrections mineures",
-                "pl": "- poprawa stabilności i drobne poprawki",
-                "pt": "- melhoria da estabilidade e correções menores"
+                "en": "- fixed sync gap errors\n- better error correction\n- improved stability",
+                "fr": "- corrigé les avertissements de décalage\n- meilleure correction des erreurs\n- stabilité améliorée",
+                "pl": "- naprawione ostrzeżenia o luce synchronizacji\n- lepsza korekta błędów\n- poprawiona stabilność",
+                "pt": "- corrigido erro de sincronização de convidados\n- melhor correção de erros\n- estabilidade melhorada"
             },
             "storeLink": "https://play.google.com/store/apps/details?id=com.digitevent.checkin2app"
         },
         "ios": {
-            "minAppVersion": "1.2.15",
+            "minAppVersion": "1.3.5",
             "releaseNotes": {
-                "en": "- improve stability & minor fixes",
-                "fr": "- amélioration de la stabilité et corrections mineures",
-                "pl": "- poprawa stabilności i drobne poprawki",
-                "pt": "- melhoria da estabilidade e correções menores"
+                "en": "- fixed sync gap errors\n- better error correction\n- improved stability",
+                "fr": "- corrigé les avertissements de décalage\n- meilleure correction des erreurs\n- stabilité améliorée",
+                "pl": "- naprawione ostrzeżenia o luce synchronizacji\n- lepsza korekta błędów\n- poprawiona stabilność",
+                "pt": "- corrigido erro de sincronização de convidados\n- melhor correção de erros\n- estabilidade melhorada"
             },
             "storeLink": "itms-apps://apps.apple.com/us/app/digitevent-check-in/id6447364824"
         }


### PR DESCRIPTION
close digitevent/orchestration#583

1.3.5 has significantly improved synchronization stability. Sync gap errors no longer happen in 1.3.5
